### PR TITLE
Fix for foreign schema imports with DB2 DECIMAL columns

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
     "name": "db2_fdw",
     "abstract": "PostgreSQL Data Wrappper to DB2 databases",
     "description": "With the Data Wrapper you can acces DB2 Tabels. Not supported for all Data Types (BLOB over 2 GByte)",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "maintainer": [
       "Wolfgang Brandl <wolfgang.brandl@chello.at>"
    ],
@@ -12,7 +12,7 @@
             "abstract": "PostgreSQL Data Wrappper to DB2 databases",
             "file": "sql/db2_fdw.sql",
             "docfile": "doc/db2_fdw.md",
-            "version": "4.0.0"
+            "version": "4.0.1"
         }
     },
     "resources": {

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ EXTENSION    = db2_fdw
 EXTVERSION   = $(shell grep default_version $(EXTENSION).control | sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
 MODULE_big   = db2_fdw
 OBJS         = db2_fdw.o db2_utils.o
-RELEASE      = 4.0.0
+RELEASE      = 4.0.1
 
 DATA         = $(wildcard sql/*--*.sql)
 DOCS         = $(wildcard doc/*.md)

--- a/db2_fdw.c
+++ b/db2_fdw.c
@@ -2016,6 +2016,8 @@ db2ImportForeignSchema (ImportForeignSchemaStmt * stmt, Oid serverOid)
 	if (typeprec < 54)
           if (typeprec == 0)
 	    appendStringInfo (&buf, "float(1)");
+          else if (typeprec < 0)
+	    appendStringInfo (&buf, "float(1)");
           else
 	    appendStringInfo (&buf, "float(%d)", typeprec);
 	else

--- a/db2_fdw.h
+++ b/db2_fdw.h
@@ -15,7 +15,7 @@
 #include <sys/types.h>
 
 /* db2_fdw version */
-#define DB2_FDW_VERSION "4.0.0"
+#define DB2_FDW_VERSION "4.0.1"
 
 #ifdef OCI_ORACLE
 /*


### PR DESCRIPTION
Fixes foreign schema imports with the DB2 DECIMAL column (eg. DECIMAL(9,2): For some reason typeprec variable can contain negative numbers which results in invalid column creation statements like float(-1154099088).